### PR TITLE
feat: 사용자 초기화 로직 수정 및 최근 사용한 모델 정보 추가

### DIFF
--- a/src/main/java/tryonu/api/controller/UserController.java
+++ b/src/main/java/tryonu/api/controller/UserController.java
@@ -7,10 +7,10 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import tryonu.api.common.wrapper.ApiResponseWrapper;
 import tryonu.api.dto.requests.UserInitRequest;
-import tryonu.api.dto.responses.UserInfoResponse;
 import tryonu.api.dto.responses.SimpleUserResponse;
 import tryonu.api.service.user.UserService;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -43,14 +43,13 @@ public class UserController {
                      "피팅 결과는 id 내림차순으로 정렬되어 포함됩니다."
     )
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "사용자 초기화 성공", 
-                    content = @Content(schema = @Schema(implementation = UserInfoResponse.class))),
+        @ApiResponse(responseCode = "201", description = "사용자 초기화 성공"),
         @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터")
     })
     @PostMapping("/init")
-    public ApiResponseWrapper<UserInfoResponse> initializeUser(@Valid @RequestBody UserInitRequest request) {
-        UserInfoResponse response = userService.initializeUser(request);
-        return ApiResponseWrapper.ofSuccess(response);
+    @ResponseStatus(HttpStatus.CREATED)
+    public void initializeUser(@Valid @RequestBody UserInitRequest request) {
+        userService.initializeUser(request);
     }
     
     /**

--- a/src/main/java/tryonu/api/converter/UserConverter.java
+++ b/src/main/java/tryonu/api/converter/UserConverter.java
@@ -5,6 +5,7 @@ import tryonu.api.dto.responses.UserInfoResponse;
 import tryonu.api.dto.responses.SimpleUserResponse;
 import tryonu.api.dto.responses.DefaultModelDto;
 import tryonu.api.dto.responses.TryOnResultDto;
+import tryonu.api.dto.responses.RecentlyUsedModel;
 import tryonu.api.domain.User;
 
 import java.util.List;
@@ -16,7 +17,36 @@ public class UserConverter {
      * SimpleUserResponse 생성
      */
     public SimpleUserResponse toSimpleUserResponse(User user) {
-        return new SimpleUserResponse(user.getId(), user.getUuid());
+        RecentlyUsedModel recentlyUsedModel = createRecentlyUsedModel(user.getRecentlyUsedModelUrl());
+        return new SimpleUserResponse(recentlyUsedModel);
+    }
+
+    /**
+     * URL에서 파일명을 추출하여 RecentlyUsedModel 생성
+     */
+    private RecentlyUsedModel createRecentlyUsedModel(String modelUrl) {
+        if (modelUrl == null || modelUrl.isEmpty()) {
+            return null;
+        }
+        
+        String imageName = extractImageNameFromUrl(modelUrl);
+        return new RecentlyUsedModel(modelUrl, imageName);
+    }
+
+    /**
+     * URL에서 이미지 파일명 추출
+     */
+    private String extractImageNameFromUrl(String url) {
+        if (url == null || url.isEmpty()) {
+            return null;
+        }
+        
+        int lastSlashIndex = url.lastIndexOf('/');
+        if (lastSlashIndex >= 0 && lastSlashIndex < url.length() - 1) {
+            return url.substring(lastSlashIndex + 1);
+        }
+        
+        return url; // URL에 '/'가 없으면 전체 문자열 반환
     }
 
     /** 

--- a/src/main/java/tryonu/api/domain/User.java
+++ b/src/main/java/tryonu/api/domain/User.java
@@ -29,10 +29,21 @@ public class User extends BaseEntity {
     @Builder.Default
     Boolean isDeleted = false;
 
+    @Column(name = "recently_used_model_url", columnDefinition = "TEXT")
+    @Setter
+    String recentlyUsedModelUrl;
+
     /**
      * 소프트 삭제된 사용자를 복구합니다.
      */
     public void restore() {
         this.isDeleted = false;
+    }
+
+    /**
+     * 최근 사용한 모델 URL을 업데이트합니다.
+     */
+    public void updateRecentlyUsedModelUrl(String modelUrl) {
+        this.recentlyUsedModelUrl = modelUrl;
     }
 }

--- a/src/main/java/tryonu/api/dto/responses/RecentlyUsedModel.java
+++ b/src/main/java/tryonu/api/dto/responses/RecentlyUsedModel.java
@@ -1,0 +1,17 @@
+package tryonu.api.dto.responses;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 최근 사용한 모델 정보 DTO
+ */
+@Schema(description = "최근 사용한 모델 정보")
+public record RecentlyUsedModel(
+    
+    @Schema(description = "모델 이미지 URL", example = "https://cdn.thatzfit.com/default/models/slim-korean-male.png")
+    String modelUrl,
+    
+    @Schema(description = "이미지 파일명", example = "slim-korean-male.png")
+    String imageName
+    
+) {}

--- a/src/main/java/tryonu/api/dto/responses/SimpleUserResponse.java
+++ b/src/main/java/tryonu/api/dto/responses/SimpleUserResponse.java
@@ -8,10 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "간단한 사용자 정보")
 public record SimpleUserResponse(
     
-    @Schema(description = "사용자 ID", example = "1")
-    Long userId,
-    
-    @Schema(description = "사용자 UUID", example = "550e8400-e29b-41d4-a716-446655440000")
-    String uuid
+    @Schema(description = "최근 사용한 모델 정보")
+    RecentlyUsedModel recentlyUsedModel
     
 ) {}

--- a/src/main/java/tryonu/api/service/tryon/TryOnServiceImpl.java
+++ b/src/main/java/tryonu/api/service/tryon/TryOnServiceImpl.java
@@ -14,6 +14,7 @@ import tryonu.api.domain.Cloth;
 import tryonu.api.domain.User;
 import tryonu.api.repository.tryonresult.TryOnResultRepository;
 import tryonu.api.repository.cloth.ClothRepository;
+import tryonu.api.repository.user.UserRepository;
 import tryonu.api.common.util.VirtualFittingUtil;
 import tryonu.api.common.util.ImageUploadUtil;
 import tryonu.api.common.util.CategoryPredictionUtil;
@@ -50,6 +51,7 @@ public class TryOnServiceImpl implements TryOnService {
     private final CategoryPredictionUtil categoryPredictionUtil;
     private final TryOnResultRepository tryOnResultRepository;
     private final ClothRepository clothRepository;
+    private final UserRepository userRepository;
     private final TryOnResultConverter tryOnResultConverter;
     private final DefaultModelRepository defaultModelRepository;
     private final UserConverter userConverter;
@@ -115,6 +117,12 @@ public class TryOnServiceImpl implements TryOnService {
             // 피팅 결과 저장
             TryOnResult tryOnResult = tryOnResultConverter.toTryOnResultEntity(cloth, currentUser, modelUrl, resultImageUrl, virtualFittingResponse.id());
             tryOnResultRepository.save(tryOnResult);
+            
+            // 사용자의 최근 사용한 모델 URL 업데이트
+            currentUser.updateRecentlyUsedModelUrl(resultImageUrl);
+            userRepository.save(currentUser);
+            log.info("[TryOnService] 사용자 최근 사용 모델 URL 업데이트 완료 - userId={}, recentlyUsedModelUrl={}", 
+                    currentUser.getId(), resultImageUrl);
             
             // 메모리 추적 종료 (성공)
             memoryTracker.endTracking("VirtualFitting-Process", true);

--- a/src/main/java/tryonu/api/service/user/UserServiceImpl.java
+++ b/src/main/java/tryonu/api/service/user/UserServiceImpl.java
@@ -63,13 +63,23 @@ public class UserServiceImpl implements UserService {
             // 기본 모델들을 배치로 생성하여 한 번에 저장
             List<DefaultModel> initialModels = new ArrayList<>();
             int initialSortOrder = 1;
+            String firstModelUrl = null;
             for (Gender gender : Gender.values()) {
-                initialModels.add(defaultModelConverter.createDefaultModel(user, gender, initialSortOrder++));
+                DefaultModel model = defaultModelConverter.createDefaultModel(user, gender, initialSortOrder++);
+                initialModels.add(model);
+                // 첫 번째 모델의 URL을 저장 (sortOrder가 1인 모델)
+                if (firstModelUrl == null) {
+                    firstModelUrl = model.getImageUrl();
+                }
             }
             defaultModelRepository.saveAll(initialModels);
 
+            // 첫 번째 기본 모델의 URL로 recentlyUsedModelUrl 설정
+            user.updateRecentlyUsedModelUrl(firstModelUrl);
+            user = userRepository.save(user);
             
-            log.info("[UserService] 새 사용자 생성 완료: userId={}, uuid={}", user.getId(), request.uuid());
+            log.info("[UserService] 새 사용자 생성 완료: userId={}, uuid={}, recentlyUsedModelUrl={}", 
+                    user.getId(), request.uuid(), firstModelUrl);
         }
 
         List<DefaultModelDto> defaultModels = defaultModelRepository.findDefaultModelsByUserIdOrderBySortOrder(user.getId());


### PR DESCRIPTION
- 사용자 초기화 API의 응답 상태 코드를 201로 변경하고, 반환 타입을 void로 수정하여 간소화
- 사용자 정보 응답에 최근 사용한 모델 정보를 포함하도록 SimpleUserResponse 수정
- User 엔티티에 recentlyUsedModelUrl 필드 추가 및 업데이트 메서드 구현
- UserConverter에서 최근 사용한 모델 정보를 생성하는 로직 추가
- TryOnServiceImpl에서 사용자의 최근 사용한 모델 URL 업데이트 로직 추가
- UserServiceImpl에서 새 사용자 생성 시 첫 번째 모델의 URL로 recentlyUsedModelUrl 설정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The app now tracks and returns a user’s recently used model (URL and image name) in simple user responses.
  - New users are auto-initialized with a default model as their recently used model.

- Documentation
  - The initialize user endpoint now returns HTTP 201 Created with no response body; API documentation updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->