### PR TITLE
feat: 사용자 UUID 조회에 비관적 락 기능 repository 레이어로 분리

### DIFF
--- a/src/main/java/tryonu/api/repository/user/JpaUserRepository.java
+++ b/src/main/java/tryonu/api/repository/user/JpaUserRepository.java
@@ -1,30 +1,41 @@
 package tryonu.api.repository.user;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.lang.NonNull;
 import tryonu.api.domain.User;
+import jakarta.persistence.LockModeType;
 
 import java.util.Optional;
 
 public interface JpaUserRepository extends JpaRepository<User, Long> {
-    
+
     /**
      * id와 삭제되지 않은 사용자 조회
      */
     Optional<User> findByIdAndIsDeletedFalse(Long id);
-    
+
     /**
      * 디바이스 ID로 삭제되지 않은 사용자 조회
      */
     Optional<User> findByUuidAndIsDeletedFalse(@NonNull String uuid);
-    
+
     /**
      * 디바이스 ID로 사용자 존재 여부 확인
      */
     boolean existsByUuidAndIsDeletedFalse(@NonNull String uuid);
 
     /**
-     * uuid로 사용자 조회
+     * uuid로 사용자 조회 (일반 조회 - 락 없음)
      */
     Optional<User> findByUuid(@NonNull String uuid);
-} 
+
+    /**
+     * uuid로 사용자 조회 (비관적 락 적용 - 동시성 제어용)
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT u FROM User u WHERE u.uuid = :uuid")
+    Optional<User> findByUuidWithLock(@Param("uuid") @NonNull String uuid);
+}

--- a/src/main/java/tryonu/api/repository/user/UserRepository.java
+++ b/src/main/java/tryonu/api/repository/user/UserRepository.java
@@ -1,40 +1,44 @@
 package tryonu.api.repository.user;
 
 import org.springframework.lang.NonNull;
-import tryonu.api.domain.User;  
+import tryonu.api.domain.User;
 import java.util.Optional;
 
-
 public interface UserRepository {
-    
+
     /**
      * 사용자 저장 (로깅 포함)
      */
     User save(@NonNull User user);
-    
+
     /**
      * 사용자 ID로 조회 (예외처리 포함)
      */
     User findByIdAndIsDeletedFalseOrThrow(@NonNull Long userId);
 
     /**
-     * 디바이스 ID로 사용자 조회
+     * 디바이스 ID로 사용자 조회 (일반 조회)
      */
     Optional<User> findByUuid(@NonNull String uuid);
-    
+
+    /**
+     * 디바이스 ID로 사용자 조회 (비관적 락 적용)
+     */
+    Optional<User> findByUuidWithLock(@NonNull String uuid);
+
     /**
      * 디바이스 ID로 사용자 조회 (예외처리 포함)
      */
     User findByUuidAndIsDeletedFalseOrThrow(@NonNull String uuid);
-    
+
     /**
      * 디바이스 ID로 사용자 존재 여부 확인
      */
     boolean existsByUuidAndIsDeletedFalse(@NonNull String uuid);
-    
+
     /**
      * 사용자 소프트 삭제 (예외처리 포함)
      */
     void softDelete(@NonNull User user);
-    
-} 
+
+}

--- a/src/main/java/tryonu/api/repository/user/UserRepositoryAdapter.java
+++ b/src/main/java/tryonu/api/repository/user/UserRepositoryAdapter.java
@@ -13,54 +13,58 @@ import java.util.Optional;
 @Repository
 @RequiredArgsConstructor
 public class UserRepositoryAdapter implements UserRepository {
-    
+
     private final JpaUserRepository jpaUserRepository;
 
-    @Override
-    public Optional<User> findByUuid(@NonNull String uuid) {
-        return jpaUserRepository.findByUuid(uuid);
-    }
-    
     @Override
     public User save(@NonNull User user) {
         User savedUser = jpaUserRepository.save(user);
         log.debug("[UserRepositoryAdapter] 사용자 저장 - uuid: {}", savedUser.getUuid());
         return savedUser;
     }
-    
+
     @Override
     public User findByIdAndIsDeletedFalseOrThrow(@NonNull Long userId) {
         return jpaUserRepository.findByIdAndIsDeletedFalse(userId)
-            .orElseThrow(() -> {
-                log.error("[UserRepositoryAdapter] 사용자를 찾을 수 없음 - userId: {}", userId);
-                return new CustomException(ErrorCode.USER_NOT_FOUND, 
-                    String.format("사용자 ID '%d'에 해당하는 사용자를 찾을 수 없습니다.", userId));
-            });
+                .orElseThrow(() -> {
+                    log.error("[UserRepositoryAdapter] 사용자를 찾을 수 없음 - userId: {}", userId);
+                    return new CustomException(ErrorCode.USER_NOT_FOUND,
+                            String.format("사용자 ID '%d'에 해당하는 사용자를 찾을 수 없습니다.", userId));
+                });
     }
-    
+
+    @Override
+    public Optional<User> findByUuid(@NonNull String uuid) {
+        return jpaUserRepository.findByUuid(uuid);
+    }
+
+    @Override
+    public Optional<User> findByUuidWithLock(@NonNull String uuid) {
+        return jpaUserRepository.findByUuidWithLock(uuid);
+    }
+
     @Override
     public User findByUuidAndIsDeletedFalseOrThrow(@NonNull String uuid) {
         return jpaUserRepository.findByUuidAndIsDeletedFalse(uuid)
-            .orElseThrow(() -> {
-                log.error("[UserRepositoryAdapter] 사용자를 찾을 수 없음 - uuid: {}", uuid);
-                return new CustomException(ErrorCode.USER_NOT_FOUND, 
-                    String.format("uuid '%s'에 해당하는 사용자를 찾을 수 없습니다.", uuid));
-            });
+                .orElseThrow(() -> {
+                    log.error("[UserRepositoryAdapter] 사용자를 찾을 수 없음 - uuid: {}", uuid);
+                    return new CustomException(ErrorCode.USER_NOT_FOUND,
+                            String.format("uuid '%s'에 해당하는 사용자를 찾을 수 없습니다.", uuid));
+                });
     }
-    
-    
+
     @Override
     public boolean existsByUuidAndIsDeletedFalse(@NonNull String uuid) {
         boolean exists = jpaUserRepository.existsByUuidAndIsDeletedFalse(uuid);
         log.debug("[UserRepositoryAdapter] 사용자 존재 여부 확인 - uuid: {}, exists: {}", uuid, exists);
         return exists;
     }
-    
+
     @Override
     public void softDelete(@NonNull User user) {
         user.setIsDeleted(true);
         jpaUserRepository.save(user);
         log.debug("[UserRepositoryAdapter] 사용자 소프트 삭제 - uuid: {}", user.getUuid());
     }
-    
-} 
+
+}


### PR DESCRIPTION
- lock을 거는 uuid 조회와 그렇지 않은 uuid 조회 쿼리로 분리하여 성능 최적화
- user/init (레이스 컨디션 발생했던 엔드포인트)에선 비관적 락 적용 -> 레포지토리 레이어로 책임 위임

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Improved reliability when initializing or retrieving a user under high concurrency, reducing race conditions and preventing duplicate account creation or intermittent errors during signup/first launch.

- Refactor
  - Centralized concurrency control in the data layer for consistent behavior across user lookups, ensuring safer updates under load and clearer responsibility boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->