### PR TITLE
[FIX] 헬스체크 엔드포인트 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,6 @@ ENV JAVA_OPTS="-Xms256m -Xmx768m -XX:+UseG1GC -XX:+UseContainerSupport \
 -XX:+UseStringDeduplication -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/"
 
 HEALTHCHECK --interval=5s --timeout=3s --start-period=60s --retries=10 \
-  CMD curl -f http://localhost:8080/actuator/health || exit 1
+  CMD curl -f http://localhost:8080/api/health || exit 1
 
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -Dspring.profiles.active=prod -jar app.jar"] 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the container health check to query http://localhost:8080/api/health instead of the previous endpoint. This ensures the container reports its status based on the current API health endpoint. No other container behavior or configuration changed, and the existing success/failure logic remains the same. Users running the image should see consistent health reporting in orchestrators and container platforms without any additional configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->